### PR TITLE
Fix last word count calculation for full word

### DIFF
--- a/quickfilter.go
+++ b/quickfilter.go
@@ -189,7 +189,7 @@ func (qf QuickFilter) UnionOf(qf1, qf2 QuickFilter) QuickFilter {
 
 	i := len(qf.bits) - 1
 	qf.bits[i] = qf1.bits[i] | qf2.bits[i]
-	qf.len += onesCountLastWord(qf.bits[i], qf.sourceLen%bits.UintSize)
+	qf.len += onesCountLastWord(qf.bits[i], qf.sourceLen % bits.UintSize)
 
 	return qf
 }
@@ -220,7 +220,7 @@ func (qf QuickFilter) IntersectionOf(qf1, qf2 QuickFilter) QuickFilter {
 
 	i := len(qf.bits) - 1
 	qf.bits[i] = qf1.bits[i] & qf2.bits[i]
-	qf.len += onesCountLastWord(qf.bits[i], qf.sourceLen%bits.UintSize)
+	qf.len += onesCountLastWord(qf.bits[i], qf.sourceLen % bits.UintSize)
 
 	return qf
 }
@@ -286,5 +286,5 @@ func offsets(pos int) (index int, mask uint) {
 //
 // We shift by the number of unused bits to have only first usedBitsCount bits left and then count.
 func onesCountLastWord(word uint, usedBitsCount int) int {
-	return bits.OnesCount(word << uint(bits.UintSize-usedBitsCount))
+	return bits.OnesCount(word << uint(bits.UintSize - usedBitsCount))
 }

--- a/quickfilter.go
+++ b/quickfilter.go
@@ -178,7 +178,7 @@ func (qf QuickFilter) UnionOf(qf1, qf2 QuickFilter) QuickFilter {
 	}
 	qf.len = 0
 	fullWords := len(qf.bits)
-	if qf.sourceLen%bits.UintSize > 0 {
+	if qf.sourceLen % bits.UintSize > 0 {
 		fullWords = fullWords - 1
 	}
 
@@ -209,7 +209,7 @@ func (qf QuickFilter) IntersectionOf(qf1, qf2 QuickFilter) QuickFilter {
 	}
 	qf.len = 0
 	fullWords := len(qf.bits)
-	if qf.sourceLen%bits.UintSize > 0 {
+	if qf.sourceLen % bits.UintSize > 0 {
 		fullWords = fullWords - 1
 	}
 

--- a/quickfilter.go
+++ b/quickfilter.go
@@ -177,14 +177,19 @@ func (qf QuickFilter) UnionOf(qf1, qf2 QuickFilter) QuickFilter {
 		panic("receiver and passed QuickFilters must be the same size")
 	}
 	qf.len = 0
-	for i := range qf.bits[:len(qf.bits)-1] {
+	fullWords := len(qf.bits)
+	if qf.sourceLen%bits.UintSize > 0 {
+		fullWords = fullWords - 1
+	}
+
+	for i := range qf.bits[:fullWords] {
 		qf.bits[i] = qf1.bits[i] | qf2.bits[i]
 		qf.len += bits.OnesCount(qf.bits[i])
 	}
 
 	i := len(qf.bits) - 1
 	qf.bits[i] = qf1.bits[i] | qf2.bits[i]
-	qf.len += onesCountLastWord(qf.bits[i], qf.sourceLen % bits.UintSize)
+	qf.len += onesCountLastWord(qf.bits[i], qf.sourceLen%bits.UintSize)
 
 	return qf
 }
@@ -203,14 +208,19 @@ func (qf QuickFilter) IntersectionOf(qf1, qf2 QuickFilter) QuickFilter {
 		panic("receiver and passed QuickFilters must be the same size")
 	}
 	qf.len = 0
-	for i := range qf.bits[:len(qf.bits)-1] {
+	fullWords := len(qf.bits)
+	if qf.sourceLen%bits.UintSize > 0 {
+		fullWords = fullWords - 1
+	}
+
+	for i := range qf.bits[:fullWords] {
 		qf.bits[i] = qf1.bits[i] & qf2.bits[i]
 		qf.len += bits.OnesCount(qf.bits[i])
 	}
 
 	i := len(qf.bits) - 1
 	qf.bits[i] = qf1.bits[i] & qf2.bits[i]
-	qf.len += onesCountLastWord(qf.bits[i], qf.sourceLen % bits.UintSize)
+	qf.len += onesCountLastWord(qf.bits[i], qf.sourceLen%bits.UintSize)
 
 	return qf
 }
@@ -276,5 +286,5 @@ func offsets(pos int) (index int, mask uint) {
 //
 // We shift by the number of unused bits to have only first usedBitsCount bits left and then count.
 func onesCountLastWord(word uint, usedBitsCount int) int {
-	return bits.OnesCount(word << uint(bits.UintSize - usedBitsCount))
+	return bits.OnesCount(word << uint(bits.UintSize-usedBitsCount))
 }

--- a/quickfilter.go
+++ b/quickfilter.go
@@ -177,7 +177,7 @@ func (qf QuickFilter) UnionOf(qf1, qf2 QuickFilter) QuickFilter {
 		panic("receiver and passed QuickFilters must be the same size")
 	}
 	qf.len = 0
-	for i := range qf.bits[:len(qf.bits) - 1] {
+	for i := range qf.bits[:len(qf.bits)-1] {
 		qf.bits[i] = qf1.bits[i] | qf2.bits[i]
 		qf.len += bits.OnesCount(qf.bits[i])
 	}
@@ -203,7 +203,7 @@ func (qf QuickFilter) IntersectionOf(qf1, qf2 QuickFilter) QuickFilter {
 		panic("receiver and passed QuickFilters must be the same size")
 	}
 	qf.len = 0
-	for i := range qf.bits[:len(qf.bits) - 1] {
+	for i := range qf.bits[:len(qf.bits)-1] {
 		qf.bits[i] = qf1.bits[i] & qf2.bits[i]
 		qf.len += bits.OnesCount(qf.bits[i])
 	}

--- a/quickfilter_test.go
+++ b/quickfilter_test.go
@@ -317,6 +317,20 @@ func Test(t *testing.T) {
 		}
 	})
 
+	t.Run("Fill full Words, Union with the same and check length", func(t *testing.T) {
+		sourceLen := 9408
+		qf1 := quickfilter.NewFilled(sourceLen)
+		qf2 := quickfilter.NewFilled(sourceLen)
+
+		qf2 = qf1.UnionOf(qf1, qf2)
+
+		got := qf2.Len()
+		expectedLen := 9408
+		if expectedLen != got {
+			t.Errorf("expected %d, got %d", expectedLen, got)
+		}
+	})
+
 	t.Run("Fill, Union and check length", func(t *testing.T) {
 		expectedLen := 10
 		qf1 := quickfilter.NewFilled(expectedLen)

--- a/quickfilter_test.go
+++ b/quickfilter_test.go
@@ -331,6 +331,20 @@ func Test(t *testing.T) {
 		}
 	})
 
+	t.Run("Fill full Words, Intersect with the same and check length", func(t *testing.T) {
+		sourceLen := 9408
+		qf1 := quickfilter.NewFilled(sourceLen)
+		qf2 := quickfilter.NewFilled(sourceLen)
+
+		qf2 = qf1.IntersectionOf(qf1, qf2)
+
+		got := qf2.Len()
+		expectedLen := 9408
+		if expectedLen != got {
+			t.Errorf("expected %d, got %d", expectedLen, got)
+		}
+	})
+
 	t.Run("Fill, Union and check length", func(t *testing.T) {
 		expectedLen := 10
 		qf1 := quickfilter.NewFilled(expectedLen)


### PR DESCRIPTION
The issue happens when `qf.sourceLen % bits.UintSize == 0 `

As a result `onesCountLastWord` would be called as `onesCountLastWord(qf.bits[i], 0)`
The result of this call would be `return bits.OnesCount(word << 64) == bits.OnesCount(0) == 0` so that the last word ones count is just lost because of that 

The fix is to take the case when `qf.sourceLen % bits.UintSize == 0` into account and use `bits.UintSize ` instead because it means that all bits in the word are used

